### PR TITLE
Fix Arch build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-CMakeFiles
-CMakeCache*
+#CMakeFiles
+#CMakeCache*
 *.user
 Makefile
 *.*~

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Andrey Golubev
+# Copyright 2021 Andrey Golubev
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -27,33 +27,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 2.8)
-project(clsc)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
+# suppress 3rdparty warnings
+add_compile_options(-Wno-maybe-uninitialized)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS}")
-
-option(WITH_ASAN "Enable ASan build flags" OFF)
-
-if (${WITH_ASAN})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak -fsanitize=undefined")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libsan")
-  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libasan")
-  endif()
-endif (${WITH_ASAN})
-
-# gtest
-set(BUILD_GMOCK OFF CACHE BOOL "Exclude gmock from build")
-set(INSTALL_GTEST OFF CACHE BOOL "Do not install gtest")
-add_subdirectory(external)
-
-# clsc
-add_subdirectory(utilities)
-add_subdirectory(algorithm)
-add_subdirectory(tests)
+add_subdirectory(googletest)

--- a/script/test.py
+++ b/script/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018 Andrey Golubev
+# Copyright 2018-2021 Andrey Golubev
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -73,9 +73,11 @@ def main():
     """Main entrypoint"""
     args = parse_args()
     workdir = os.path.join(os.path.dirname(__file__), '..', 'build')
-    if args.rebuild:
-        if os.path.exists(workdir):
+    if os.path.exists(workdir):
+        if args.rebuild:
             shutil.rmtree(workdir)
+            os.makedirs(workdir)
+    else:
         os.makedirs(workdir)
     cmake_args = args.cmake_args
     for i, arg in enumerate(cmake_args):


### PR DESCRIPTION
GCC on Arch detects unitialized variables in gtest code,
so suppress that

.gitignore and test.py patched along the way